### PR TITLE
fixed rgba array error

### DIFF
--- a/clustering_example/visualize_vectors.py
+++ b/clustering_example/visualize_vectors.py
@@ -13,7 +13,7 @@ def visualize(vectors):
     plt.scatter(
         projected_vectors[:, 0],
         projected_vectors[:, 1],
-        zs=projected_vectors[:, 2],
+        c=projected_vectors[:, 2],
         s=200,
     )
     plt.show()


### PR DESCRIPTION
The error was non-terminating in Python 3, but was able to find a fix by replacing the variable name. Possibly `matplotlib` changed something between versions?